### PR TITLE
Improve chat error handling

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -403,13 +403,22 @@ function detectProvider(url?: string | null): ProviderKey | undefined {
   return undefined
 }
 
-function parseProviderErrorData(data: unknown, responseBody?: string | null) {
+type ParsedProviderError = {
+  message?: string
+  code?: string
+  type?: string
+}
+
+function parseProviderErrorData(
+  data: unknown,
+  responseBody?: string | null,
+): ParsedProviderError {
   const parsed = extractErrorData(data) ?? extractErrorData(safeParseErrorBody(responseBody))
 
   return parsed ?? {}
 }
 
-function extractErrorData(raw: unknown) {
+function extractErrorData(raw: unknown): ParsedProviderError | undefined {
   if (!raw || typeof raw !== 'object') return undefined
 
   const container =

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -1,12 +1,14 @@
 import {
   type Message,
+  APICallError,
+  NoSuchModelError,
   createDataStreamResponse,
   smoothStream,
   streamText,
 } from 'ai'
 
 import { auth } from '@/app/(auth)/auth'
-import { myProvider } from '@/lib/ai/models'
+import { chatModels, myProvider } from '@/lib/ai/models'
 import { systemPrompt } from '@/lib/ai/prompts/system-prompt'
 import {
   generateUUID,
@@ -21,6 +23,7 @@ import { requestSuggestions } from '@/lib/ai/tools/request-suggestions'
 import { getWeather } from '@/lib/ai/tools/get-weather'
 import { search } from '@/lib/ai/tools/search/search'
 import { deleteChatById, getChatById, saveChat, saveMessages } from '@/prisma/queries/chat'
+import { CopilotAPIError, getCopilotFallbackMessage } from '@/lib/ai/copilot/errors'
 
 export const maxDuration = 60
 
@@ -46,6 +49,16 @@ export async function POST(request: Request) {
 
   if (!session || !session.user || !session.user.id) {
     return new Response('Unauthorized', { status: 401 })
+  }
+
+  if (!selectedChatModel) {
+    return new Response('Chat model is required', { status: 400 })
+  }
+
+  const isKnownModel = chatModels.some((model) => model.id === selectedChatModel)
+
+  if (!isKnownModel) {
+    return new Response('Unknown chat model', { status: 400 })
   }
 
   const userMessage = getMostRecentUserMessage(messages)
@@ -161,8 +174,14 @@ export async function POST(request: Request) {
       })
     },
     onError: (error) => {
-      console.error(error)
-      return 'Oops, an error occured!'
+      const { serialized, logDetails } = serializeChatStreamError(
+        error,
+        selectedChatModel,
+      )
+
+      console.error('Chat stream error', logDetails)
+
+      return serialized
     },
   })
 }
@@ -199,5 +218,258 @@ export async function DELETE(request: Request) {
       status: 500,
     })
   }
+}
+
+type ProviderKey = 'copilot' | 'github-models'
+
+const DEFAULT_STREAM_ERROR_MESSAGE =
+  'Não foi possível concluir a solicitação. Tente novamente em instantes.'
+
+const PROVIDER_DISPLAY_NAME: Record<ProviderKey, string> = {
+  copilot: 'Copilot',
+  'github-models': 'GitHub Models',
+}
+
+const PROVIDER_STATUS_TEMPLATES: Record<number, string> = {
+  400: 'O {provider} considerou a solicitação inválida.',
+  401: 'As credenciais informadas não foram aceitas pelo {provider}.',
+  403: 'O {provider} recusou a solicitação.',
+  404: 'O recurso solicitado não foi encontrado no {provider}.',
+  408: 'O {provider} demorou para responder. Tente novamente.',
+  409: 'O {provider} está processando outra solicitação semelhante. Aguarde e tente novamente.',
+  422: 'O {provider} não conseguiu processar a solicitação enviada.',
+  429: 'O {provider} atingiu o limite de requisições permitido.',
+  500: 'O {provider} retornou um erro interno.',
+  502: 'O {provider} enviou uma resposta inválida.',
+  503: 'O {provider} está indisponível no momento. Tente novamente mais tarde.',
+  504: 'O {provider} demorou para responder. Tente novamente em instantes.',
+}
+
+function serializeChatStreamError(error: unknown, modelId?: string) {
+  const timestamp = new Date().toISOString()
+
+  if (error instanceof CopilotAPIError) {
+    const message = error.message || getCopilotFallbackMessage(error.status)
+
+    return {
+      serialized: createStreamErrorPayload({
+        message,
+        type: 'provider_error',
+        statusCode: error.status,
+        provider: 'copilot',
+        code: error.code,
+        reference: error.requestId,
+        modelId,
+        timestamp,
+      }),
+      logDetails: {
+        scope: 'chat-provider',
+        provider: 'copilot',
+        statusCode: error.status,
+        code: error.code,
+        reference: error.requestId,
+        modelId,
+        message,
+      },
+    }
+  }
+
+  if (APICallError.isInstance(error)) {
+    const provider = detectProvider(error.url)
+    const parsed = parseProviderErrorData(error.data, error.responseBody)
+    const statusCode = typeof error.statusCode === 'number' ? error.statusCode : undefined
+    const requestId = extractRequestId(error.responseHeaders)
+    const providerMessage = parsed.message ?? (typeof error.message === 'string' ? error.message : undefined)
+    const fallbackMessage =
+      fallbackMessageForProvider(statusCode, provider) ?? DEFAULT_STREAM_ERROR_MESSAGE
+    const message = providerMessage && providerMessage.trim().length > 0 ? providerMessage : fallbackMessage
+
+    return {
+      serialized: createStreamErrorPayload({
+        message,
+        type: 'provider_error',
+        statusCode,
+        provider,
+        code: parsed.code,
+        reference: requestId,
+        modelId,
+        timestamp,
+      }),
+      logDetails: {
+        scope: 'chat-provider',
+        provider,
+        statusCode,
+        code: parsed.code,
+        reference: requestId,
+        modelId,
+        message,
+      },
+    }
+  }
+
+  if (NoSuchModelError.isInstance(error)) {
+    const message =
+      'O modelo selecionado não está disponível. Atualize a página e selecione outro modelo.'
+
+    return {
+      serialized: createStreamErrorPayload({
+        message,
+        type: 'configuration_error',
+        modelId,
+        timestamp,
+      }),
+      logDetails: {
+        scope: 'chat-configuration',
+        modelId,
+        message,
+      },
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      serialized: createStreamErrorPayload({
+        message: DEFAULT_STREAM_ERROR_MESSAGE,
+        type: 'internal_error',
+        modelId,
+        timestamp,
+      }),
+      logDetails: {
+        scope: 'chat-internal',
+        modelId,
+        error: error.message,
+        stack: error.stack,
+      },
+    }
+  }
+
+  return {
+    serialized: createStreamErrorPayload({
+      message: DEFAULT_STREAM_ERROR_MESSAGE,
+      type: 'internal_error',
+      modelId,
+      timestamp,
+    }),
+    logDetails: {
+      scope: 'chat-unknown',
+      modelId,
+      error,
+    },
+  }
+}
+
+function createStreamErrorPayload({
+  message,
+  type,
+  statusCode,
+  provider,
+  code,
+  reference,
+  modelId,
+  timestamp,
+}: {
+  message: string
+  type: string
+  statusCode?: number
+  provider?: ProviderKey
+  code?: string
+  reference?: string
+  modelId?: string
+  timestamp: string
+}) {
+  const payload: Record<string, unknown> = {
+    message,
+    type,
+    timestamp,
+  }
+
+  if (typeof statusCode === 'number') payload.statusCode = statusCode
+  if (provider) payload.provider = provider
+  if (code) payload.code = code
+  if (reference) payload.reference = reference
+  if (modelId) payload.modelId = modelId
+
+  return JSON.stringify(payload)
+}
+
+function detectProvider(url?: string | null): ProviderKey | undefined {
+  if (!url) return undefined
+
+  const normalized = url.toLowerCase()
+
+  if (normalized.includes('copilot')) return 'copilot'
+  if (normalized.includes('models.inference.ai.azure.com')) return 'github-models'
+
+  return undefined
+}
+
+function parseProviderErrorData(data: unknown, responseBody?: string | null) {
+  const parsed = extractErrorData(data) ?? extractErrorData(safeParseErrorBody(responseBody))
+
+  return parsed ?? {}
+}
+
+function extractErrorData(raw: unknown) {
+  if (!raw || typeof raw !== 'object') return undefined
+
+  const container =
+    'error' in (raw as Record<string, unknown>) &&
+    typeof (raw as Record<string, unknown>).error === 'object' &&
+    (raw as Record<string, unknown>).error !== null
+      ? (raw as Record<string, unknown>).error as Record<string, unknown>
+      : (raw as Record<string, unknown>)
+
+  const message = typeof container.message === 'string' ? container.message : undefined
+  const codeValue = container.code
+  const code =
+    typeof codeValue === 'string'
+      ? codeValue
+      : typeof codeValue === 'number'
+        ? codeValue.toString()
+        : undefined
+
+  const type = typeof container.type === 'string' ? container.type : undefined
+
+  if (!message && !code && !type) {
+    return undefined
+  }
+
+  return { message, code, type }
+}
+
+function safeParseErrorBody(body?: string | null) {
+  if (!body) return undefined
+
+  try {
+    return JSON.parse(body)
+  } catch {
+    return undefined
+  }
+}
+
+function fallbackMessageForProvider(statusCode?: number, provider?: ProviderKey) {
+  if (typeof statusCode !== 'number') return undefined
+
+  if (provider === 'copilot') {
+    return getCopilotFallbackMessage(statusCode)
+  }
+
+  const template = PROVIDER_STATUS_TEMPLATES[statusCode]
+
+  if (!template) return undefined
+
+  const providerName = provider ? PROVIDER_DISPLAY_NAME[provider] : 'o provedor de modelos'
+
+  return template.replace('{provider}', providerName)
+}
+
+function extractRequestId(headers?: Record<string, string>) {
+  if (!headers) return undefined
+
+  return (
+    headers['x-request-id'] ??
+    headers['x-github-request-id'] ??
+    headers['x-ms-request-id']
+  )
 }
 

--- a/app/api/copilot/chat/completions/route.ts
+++ b/app/api/copilot/chat/completions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { listModels, proxyChatCompletions } from '../../../../../lib/ai/copilot/service'
+import { CopilotAPIError } from '../../../../../lib/ai/copilot/errors'
 import { initializeProxy } from '../../../../../lib/ai/copilot/proxy'
 
 initializeProxy()
@@ -9,8 +10,11 @@ export async function GET(request: NextRequest) {
     const token = request.headers.get('Authorization')
     const models = await listModels(token)
     return NextResponse.json(models)
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+  } catch (error) {
+    return handleCopilotError(
+      error,
+      'Não foi possível recuperar os modelos do Copilot.'
+    )
   }
 }
 
@@ -26,7 +30,39 @@ export async function POST(request: NextRequest) {
     }
     const data = await response.json()
     return NextResponse.json(data)
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+  } catch (error) {
+    return handleCopilotError(
+      error,
+      'Não foi possível completar a solicitação no Copilot.'
+    )
   }
+}
+
+function handleCopilotError(error: unknown, fallbackMessage: string) {
+  if (error instanceof CopilotAPIError) {
+    console.error('Copilot API error', {
+      message: error.message,
+      status: error.status,
+      code: error.code,
+      requestId: error.requestId,
+    })
+
+    return NextResponse.json(error.toResponseBody(), {
+      status: error.status,
+    })
+  }
+
+  console.error('Unexpected Copilot proxy error', error)
+
+  return NextResponse.json(
+    {
+      error: {
+        message: fallbackMessage,
+        type: 'unexpected_error',
+        code: 'copilot_unexpected_error',
+        param: null,
+      },
+    },
+    { status: 500 }
+  )
 }

--- a/lib/ai/copilot/errors.ts
+++ b/lib/ai/copilot/errors.ts
@@ -1,0 +1,151 @@
+type ErrorBody = {
+  error?: {
+    message?: unknown
+    type?: unknown
+    code?: unknown
+    param?: unknown
+  }
+  message?: unknown
+  code?: unknown
+  type?: unknown
+  detail?: unknown
+  errors?: unknown
+}
+
+const STATUS_MESSAGE_MAP: Record<number, string> = {
+  400: 'A solicitação enviada ao Copilot é inválida.',
+  401: 'A chave de API do Copilot é inválida ou não foi informada.',
+  403: 'O Copilot recusou a solicitação. Verifique as permissões da chave de API.',
+  404: 'O recurso solicitado no Copilot não foi encontrado.',
+  408: 'A solicitação ao Copilot expirou. Tente novamente.',
+  409: 'O Copilot está processando uma solicitação semelhante. Aguarde e tente novamente.',
+  422: 'O Copilot não conseguiu processar a solicitação enviada.',
+  429: 'O Copilot retornou limite de requisições. Aguarde e tente novamente.',
+  500: 'O Copilot encontrou um erro interno.',
+  502: 'O serviço do Copilot retornou uma resposta inválida.',
+  503: 'O Copilot está indisponível no momento. Tente novamente mais tarde.',
+  504: 'O Copilot demorou para responder. Tente novamente em instantes.',
+}
+
+export function getCopilotFallbackMessage(status: number): string {
+  return STATUS_MESSAGE_MAP[status] ?? 'Não foi possível comunicar com o Copilot no momento.'
+}
+
+function toStringOrUndefined(value: unknown): string | undefined {
+  if (value == null) return undefined
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') return value.toString()
+  return undefined
+}
+
+function extractErrorFields(body: ErrorBody | undefined) {
+  if (!body) return {}
+
+  const candidate = typeof body.error === 'object' && body.error !== null ? body.error : body
+
+  return {
+    message: toStringOrUndefined((candidate as ErrorBody['error'])?.message),
+    type: toStringOrUndefined((candidate as ErrorBody['error'])?.type),
+    code: toStringOrUndefined((candidate as ErrorBody['error'])?.code),
+    param: (candidate as ErrorBody['error'])?.param,
+  }
+}
+
+export interface CopilotAPIErrorOptions {
+  message: string
+  status: number
+  code?: string
+  type?: string
+  requestId?: string
+  details?: unknown
+  rawBody?: string
+  cause?: unknown
+}
+
+export class CopilotAPIError extends Error {
+  readonly status: number
+  readonly code?: string
+  readonly type: string
+  readonly requestId?: string
+  readonly details?: unknown
+  readonly rawBody?: string
+
+  constructor({
+    message,
+    status,
+    code,
+    type = 'copilot_api_error',
+    requestId,
+    details,
+    rawBody,
+    cause,
+  }: CopilotAPIErrorOptions) {
+    super(message)
+    this.name = 'CopilotAPIError'
+    this.status = status
+    this.code = code
+    this.type = type
+    this.requestId = requestId
+    this.details = details
+    this.rawBody = rawBody
+
+    if (cause !== undefined) {
+      const withCause = this as Error & { cause?: unknown }
+      withCause.cause = cause
+    }
+  }
+
+  toResponseBody() {
+    return {
+      error: {
+        message: this.message,
+        type: this.type,
+        code: this.code ?? this.type,
+        param: null,
+      },
+    }
+  }
+}
+
+export async function buildCopilotAPIError(response: Response): Promise<CopilotAPIError> {
+  const requestId =
+    response.headers.get('x-request-id') ??
+    response.headers.get('x-github-request-id') ??
+    response.headers.get('x-ms-request-id') ??
+    undefined
+
+  const rawBody = await response.text()
+  let parsedBody: ErrorBody | undefined
+
+  if (rawBody) {
+    try {
+      parsedBody = JSON.parse(rawBody)
+    } catch {
+      parsedBody = undefined
+    }
+  }
+
+  const fields = extractErrorFields(parsedBody)
+  const fallbackMessage = getCopilotFallbackMessage(response.status)
+  const message = fields.message?.trim() ? fields.message : fallbackMessage
+
+  return new CopilotAPIError({
+    message,
+    status: response.status,
+    code: fields.code,
+    type: fields.type ?? 'copilot_api_error',
+    requestId,
+    details: parsedBody ?? rawBody,
+    rawBody,
+  })
+}
+
+export function buildCopilotConnectionError(error: unknown): CopilotAPIError {
+  return new CopilotAPIError({
+    message: 'Não foi possível se conectar ao Copilot. Verifique a sua rede e a chave de API.',
+    status: 503,
+    code: 'copilot_unreachable',
+    type: 'service_unavailable',
+    cause: error,
+  })
+}

--- a/lib/ai/copilot/service.ts
+++ b/lib/ai/copilot/service.ts
@@ -1,4 +1,5 @@
 import { StringSanitizer } from './utils'
+import { buildCopilotAPIError, buildCopilotConnectionError } from './errors'
 
 const CHAT_COMPLETIONS_API_ENDPOINT = "https://api.individual.githubcopilot.com/chat/completions"
 const MODELS_API_ENDPOINT = "https://api.individual.githubcopilot.com/models"
@@ -54,16 +55,21 @@ export async function listModels(authToken?: string | null): Promise<any> {
     "editor-version": "vscode/1.95.3"
   }
 
-  const response = await fetch(MODELS_API_ENDPOINT, {
-    method: "GET",
-    headers
-  })
+  let response: Response
+
+  try {
+    response = await fetch(MODELS_API_ENDPOINT, {
+      method: "GET",
+      headers
+    })
+  } catch (error) {
+    throw buildCopilotConnectionError(error)
+  }
 
   if (!response.ok) {
-    const errorText = await response.text()
-    throw new Error(`Models API error: ${errorText}`)
+    throw await buildCopilotAPIError(response)
   }
-  
+
   return await response.json()
 }
 
@@ -77,16 +83,21 @@ export async function proxyChatCompletions(requestBody: any, authToken?: string 
     "editor-version": "vscode/1.95.3"
   }
   const body = preprocessRequestBody(requestBody)
-  const response = await fetch(CHAT_COMPLETIONS_API_ENDPOINT, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body)
-  })
+  let response: Response
+
+  try {
+    response = await fetch(CHAT_COMPLETIONS_API_ENDPOINT, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body)
+    })
+  } catch (error) {
+    throw buildCopilotConnectionError(error)
+  }
 
   if (!response.ok) {
-    const errorText = await response.text()
-    throw new Error(`API error: ${errorText}`)
+    throw await buildCopilotAPIError(response)
   }
-  
+
   return response
 }


### PR DESCRIPTION
## Summary
- add Copilot-specific error helpers to normalize provider failures
- update the Copilot proxy and service to return structured error payloads with contextual logging
- harden the /api/chat endpoint with model validation and detailed streaming error serialization

## Testing
- pnpm lint
- COPILOT_TOKEN=gustavo pnpm dev (manual) followed by curl -s -D - -X POST http://localhost:3000/api/copilot/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer gustavo' -d '{"model":"gpt-4o-mini-copilot","messages":[{"role":"user","content":"Hello"}],"stream":false}'

------
https://chatgpt.com/codex/tasks/task_e_68c962461b648332a36d2485eac43e58